### PR TITLE
fix: exceptions now has message in dictionary

### DIFF
--- a/supafunc/errors.py
+++ b/supafunc/errors.py
@@ -12,6 +12,7 @@ class FunctionsApiErrorDict(TypedDict):
 class FunctionsError(Exception):
     def __init__(self, message: str, name: str, status: int) -> None:
         super().__init__(message)
+        self.message = message
         self.name = name
         self.status = status
 

--- a/tests/_async/test_function_client.py
+++ b/tests/_async/test_function_client.py
@@ -68,5 +68,17 @@ async def test_invoke_with_non_200_response():
             return_value=Response(404),
             side_effect=FunctionsHttpError("Http error!"),
         )
-        with pytest.raises(FunctionsHttpError, match=r"Http error!"):
+        with pytest.raises(FunctionsHttpError, match=r"Http error!") as exc:
             await function_client().invoke(function_name="hello-world")
+        assert exc.value.message == "Http error!"
+
+
+async def test_relay_error_message():
+    async with respx.mock:
+        respx.post(f"{FUNCTIONS_URL}/hello-world").mock(
+            return_value=Response(200, headers={"x-relay-header": "true"}),
+            side_effect=FunctionsRelayError("Relay error!"),
+        )
+        with pytest.raises(FunctionsRelayError, match=r"Relay error!") as exc:
+            await function_client().invoke(function_name="hello-world")
+        assert exc.value.message == "Relay error!"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix and added tests to check for the messages from exceptions.

## What is the current behavior?

There is no message in the dictionary you get from an exception

## What is the new behavior?

There is a message in the dictionary you get from an exception

## Additional context

Add any other context or screenshots.
