### PR TITLE
ci: update workflow with new pypi project name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     needs: test
     if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/main' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.repository_owner == 'supabase-community' }}
     runs-on: ubuntu-latest
-    name: "Bump version, create changelog and publish"
+    name: "supabase_functions: Bump version, create changelog and publish"
     environment:
       name: pypi
       url: https://pypi.org/p/supabase_functions
@@ -73,7 +73,7 @@ jobs:
     needs: test
     if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/main' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.repository_owner == 'supabase-community' }}
     runs-on: ubuntu-latest
-    name: "Bump version, create changelog and publish"
+    name: "supafunc: Bump version and publish"
     environment:
       name: pypi
       url: https://pypi.org/p/supafunc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
     name: "Bump version, create changelog and publish"
     environment:
       name: pypi
-      url: https://pypi.org/p/supafunc
+      url: https://pypi.org/p/supabase_functions
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write # needed for github actions bot to write to repo
@@ -69,3 +69,32 @@ jobs:
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+  publish_legacy:
+    needs: test
+    if: ${{ !startsWith(github.event.head_commit.message, 'bump') && !startsWith(github.event.head_commit.message, 'chore') && github.ref == 'refs/heads/main' && contains(fromJSON('["push", "workflow_dispatch"]'), github.event_name) && github.repository_owner == 'supabase-community' }}
+    runs-on: ubuntu-latest
+    name: "Bump version, create changelog and publish"
+    environment:
+      name: pypi
+      url: https://pypi.org/p/supafunc
+    permissions:
+      id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: write # needed for github actions bot to write to repo
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+          token: ${{ secrets.SILENTWORKS_PAT }}
+      - name: Python Semantic Release
+        id: release
+        uses: python-semantic-release/python-semantic-release@v8.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # NOTE: DO NOT wrap the conditional in ${{ }} as it will always evaluate to true.
+        # See https://github.com/actions/runner/issues/1173
+        if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update CI to work with new pypi project name

## What is the current behavior?

Publish only old pypi package name

## What is the new behavior?

Publish only old and new pypi package name

## Additional context

Add any other context or screenshots.
