### PR TITLE
chore: deprecate repository in favor of monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+> This repository has been moved to the [supabase-py monorepo](https://github.com/supabase/supabase-py/tree/main/src/functions). 
+
 # Functions-py
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Deprecate this repository in favor of [monorepo](github.com/supabase/supabase-py)